### PR TITLE
Updating terrain server.

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,7 +37,7 @@ function createTerrainProvider() {
     return new Cesium.EllipsoidTerrainProvider();
   } else {
     return new Cesium.CesiumTerrainProvider({
-      url : '//cesiumjs.org/stk-terrain/tilesets/world/tiles'
+      url : '//assets.agi.com/stk-terrain/world'
     });
   }
 }


### PR DESCRIPTION
The cesiumjs.org terrain server was deprecated in 1.14.