### PR TITLE
Change AGI Terrain asset URL

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,7 +40,7 @@ function createTerrainProvider() {
     return new Cesium.EllipsoidTerrainProvider();
   } else {
     return new Cesium.CesiumTerrainProvider({
-      url : '//cesiumjs.org/stk-terrain/tilesets/world/tiles'
+      url : '//assets.agi.com/stk-terrain/v1/tilesets/world/tiles'
     });
   }
 }


### PR DESCRIPTION
The used terrain resource URL does not work anymore - therefore, the published demo is non-functional.

This changes the resources to the new official addresses.
